### PR TITLE
Fix GitHub Actions Trigger

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,32 +1,29 @@
 name: Deploy to GitHub Pages
 
 on:
-  pull_request_target:
-    types:
-      - closed
+  push:
     branches:
       - master
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '18'
-    
-    - name: Install Dependencies
-      run: npm install
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "18"
 
-    - name: Build
-      run: npm run build
+      - name: Install Dependencies
+        run: npm install
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs


### PR DESCRIPTION
Removing the requirement that the action only run when a PR is merged. This overcomplicates the process for using the token to write back to the gh-pages repository and is not needed when there are branch protections requiring that all merges must come from a PR.